### PR TITLE
Fix small typo in build Tensorflow script

### DIFF
--- a/buildTensorflow.sh
+++ b/buildTensorflow.sh
@@ -3,10 +3,9 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/extras/CUPTI/lib64
 sudo apt-get install python-numpy python-dev python-pip python-wheel
 
 git clone https://github.com/tensorflow/tensorflow.git
-cp tensorflow1.8.patch tensorflow
 cd tensorflow
 git checkout v1.8.0
-git apply tensorflow1.8.patch
+git apply ../patch/tensorflow1.8.patch
 ./configure
 
 bazel build --config=opt --config=cuda //tensorflow/tools/pip_package:build_pip_package


### PR DESCRIPTION
The patch files are no longer in the root directory but underneath
patch.